### PR TITLE
fix mailto link in contributing

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -86,4 +86,4 @@ We do not have an email listserv; all of our conversation is in GitHub. If you w
 
 ### Helping in other ways
 
-Protocol Labs occasionally is able to hire developers for part time or full time positions, to work on Multiformats. If you are interested, check out [the job listings](http://ipn.io/join/#pm). If you'd like to help in other ways, [email @jbenet directly](mailto:juan@ipfs.io?subject=Contributing to Multiformats).
+Protocol Labs occasionally is able to hire developers for part time or full time positions, to work on Multiformats. If you are interested, check out [the job listings](http://ipn.io/join/#pm). If you'd like to help in other ways, [email @jbenet directly](mailto:juan@ipfs.io?subject=Contributing%20to%20Multiformats).


### PR DESCRIPTION
The current mailto link at the bottom of the document is not rendering correctly on the GitHub site.

Per discussion on [this issue](https://github.com/github/markup/issues/1030), mailto links with subjects must have spaces URL-encoded.